### PR TITLE
feat: hide the header of the embedded note

### DIFF
--- a/src/settings.js
+++ b/src/settings.js
@@ -230,7 +230,8 @@ class SyncEmbedsSettingTab extends PluginSettingTab {
             <ul>
                 <li><code>![[Note|Alias{height:500px}]]</code> - Custom height for this embed</li>
                 <li><code>![[Note|Alias{maxHeight:600px}]]</code> - Custom max height</li>
-                <li><code>![[Note|Alias{title:false}]]</code> - Hide title for this embed</li>
+                <li><code>![[Note|Alias{title:false}]]</code> - Hide inline title for this embed</li>
+                <li><code>![[Note#Section{header:false}]]</code> - Hide section header (e.g., hide "# Section")</li>
                 <li><code>![[Note|Alias{height:400px,title:false}]]</code> - Multiple options</li>
             </ul>
             <p><em>Note: Options go inside curly braces before the closing ]]</em></p>


### PR DESCRIPTION
## Background:

I wanted to hide the header of the embedded note.

## Added Code
Now you can remove the header from the embedded note with {header:false}
```sync
![[2025-12-03#Home{header:false}]]
```

```sync
![[2025-12-03#Home|Alias{header:false}]]
```

## Example:

Embedded Note:
<img width="1122" height="585" alt="image" src="https://github.com/user-attachments/assets/d67005d9-b253-41de-bc73-cd68860de7c5" />

Before:
```sync
![[2025-12-03#Home{header:false}]]
```
<img width="503" height="165" alt="image" src="https://github.com/user-attachments/assets/f82decbf-6f98-4068-8787-d76280aacfec" />


After:
```sync
![[2025-12-03#Home{header:false}]]
```
<img width="503" height="165" alt="image" src="https://github.com/user-attachments/assets/1c700011-a1e3-44ce-9245-1468b6447550" />


## How does it work?
Moves the viewport down 1 additional line when {header:false}
```
const viewportStart = hideHeader ? startLine + 1 : startLine;
```