### PR TITLE
Add `sync-query` static-to-live hot-swap pipeline

### DIFF
--- a/src/block-extractor.js
+++ b/src/block-extractor.js
@@ -1,0 +1,93 @@
+class BlockExtractor {
+    constructor(plugin) {
+        this.plugin = plugin;
+    }
+
+    async extract(files, extractType, filterText = '') {
+        const results = [];
+        const normalizedFilter = filterText.toLowerCase();
+
+        for (const file of files) {
+            const content = await this.plugin.app.vault.cachedRead(file);
+            const blocks = this.extractBlocksByType(content, extractType);
+
+            for (const block of blocks) {
+                if (normalizedFilter && !block.originalText.toLowerCase().includes(normalizedFilter)) continue;
+                results.push({
+                    file,
+                    originalText: block.originalText,
+                    blockId: block.blockId
+                });
+            }
+        }
+
+        return results;
+    }
+
+    extractBlocksByType(content, extractType) {
+        if (extractType === 'task') return this.extractWithRegex(content, /^\s*-\s*\[[ xX-]\].*$/gm);
+        if (extractType === 'callout') return this.extractCallouts(content);
+        if (extractType === 'list') return this.extractWithRegex(content, /^\s*[-*+]\s+.*$/gm);
+
+        const merged = [];
+        merged.push(...this.extractWithRegex(content, /^\s*-\s*\[[ xX-]\].*$/gm));
+        merged.push(...this.extractCallouts(content));
+        merged.push(...this.extractWithRegex(content, /^\s*[-*+]\s+.*$/gm));
+        return this.dedupeBlocks(merged);
+    }
+
+    extractWithRegex(content, regex) {
+        const blocks = [];
+        const matches = content.matchAll(regex);
+
+        for (const match of matches) {
+            const text = match[0];
+            blocks.push({
+                originalText: text,
+                blockId: this.extractBlockId(text)
+            });
+        }
+
+        return blocks;
+    }
+
+    extractCallouts(content) {
+        const blocks = [];
+        const lines = content.split('\n');
+
+        let i = 0;
+        while (i < lines.length) {
+            if (/^>\s*\[!.*?\]/.test(lines[i])) {
+                const calloutLines = [lines[i]];
+                i += 1;
+                while (i < lines.length && lines[i].startsWith('>')) {
+                    calloutLines.push(lines[i]);
+                    i += 1;
+                }
+                const text = calloutLines.join('\n');
+                blocks.push({ originalText: text, blockId: this.extractBlockId(text) });
+            } else {
+                i += 1;
+            }
+        }
+
+        return blocks;
+    }
+
+    extractBlockId(text) {
+        const match = text.match(/\^(?<id>[A-Za-z0-9_-]+)\s*$/m);
+        return match?.groups?.id;
+    }
+
+    dedupeBlocks(blocks) {
+        const seen = new Set();
+        return blocks.filter(block => {
+            const key = `${block.originalText}::${block.blockId || ''}`;
+            if (seen.has(key)) return false;
+            seen.add(key);
+            return true;
+        });
+    }
+}
+
+module.exports = BlockExtractor;

--- a/src/query-processor.js
+++ b/src/query-processor.js
@@ -1,0 +1,137 @@
+const { Notice } = require('obsidian');
+
+class QueryProcessor {
+    constructor(plugin) {
+        this.plugin = plugin;
+    }
+
+    parseYaml(source) {
+        const config = {};
+        const lines = source.split('\n');
+
+        for (const rawLine of lines) {
+            const line = rawLine.trim();
+            if (!line || line.startsWith('#')) continue;
+            const sepIndex = line.indexOf(':');
+            if (sepIndex === -1) continue;
+
+            const key = line.slice(0, sepIndex).trim();
+            let value = line.slice(sepIndex + 1).trim();
+
+            const commentIndex = value.indexOf(' #');
+            if (commentIndex !== -1) value = value.slice(0, commentIndex).trim();
+
+            if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+                value = value.slice(1, -1);
+            }
+
+            config[key] = value;
+        }
+
+        return {
+            engine: (config.engine || 'native').toLowerCase(),
+            query: config.query || '',
+            extract: (config.extract || 'any').toLowerCase(),
+            filter: config.filter || ''
+        };
+    }
+
+    async execute(source, ctx) {
+        const config = this.parseYaml(source);
+        if (!config.query) {
+            throw new Error('sync-query requires a query field');
+        }
+
+        let files = [];
+        if (config.engine === 'native') {
+            files = this.runNativeQuery(config.query);
+        } else if (config.engine === 'dataview') {
+            files = await this.runDataviewQuery(config.query, ctx);
+        } else if (config.engine === 'regex') {
+            files = await this.runRegexQuery(config.query);
+        } else {
+            throw new Error(`Unsupported engine: ${config.engine}`);
+        }
+
+        return { config, files };
+    }
+
+    runNativeQuery(query) {
+        const tokens = query.match(/(?:[^\s"]+|"[^"]*")+/g) || [];
+        const tags = [];
+        const paths = [];
+        const textTerms = [];
+
+        tokens.forEach(token => {
+            const cleanToken = token.replace(/^"|"$/g, '');
+            if (cleanToken.startsWith('tag:')) {
+                tags.push(cleanToken.slice(4));
+            } else if (cleanToken.startsWith('path:')) {
+                paths.push(cleanToken.slice(5));
+            } else {
+                textTerms.push(cleanToken.toLowerCase());
+            }
+        });
+
+        const files = this.plugin.app.vault.getMarkdownFiles();
+        return files.filter(file => {
+            const matchesPath = paths.length === 0 || paths.some(pathTerm => file.path.toLowerCase().includes(pathTerm.toLowerCase()));
+            if (!matchesPath) return false;
+
+            const cache = this.plugin.app.metadataCache.getFileCache(file);
+            const cacheTags = (cache?.tags || []).map(tag => tag.tag);
+            const matchesTags = tags.length === 0 || tags.every(tag => cacheTags.includes(tag));
+            if (!matchesTags) return false;
+
+            const textBlob = `${file.path} ${file.basename}`.toLowerCase();
+            return textTerms.every(term => textBlob.includes(term));
+        });
+    }
+
+    async runDataviewQuery(query, ctx) {
+        const dataviewPlugin = this.plugin.app.plugins.plugins.dataview;
+        if (!dataviewPlugin || typeof dataviewPlugin.api?.pages !== 'function') {
+            new Notice('Dataview engine requested, but Dataview plugin is not installed.');
+            return [];
+        }
+
+        const pages = dataviewPlugin.api.pages(query, ctx?.sourcePath);
+        const files = [];
+
+        if (!pages) return files;
+
+        pages.forEach(page => {
+            const path = page?.file?.path;
+            if (!path) return;
+            const file = this.plugin.app.vault.getAbstractFileByPath(path);
+            if (file) files.push(file);
+        });
+
+        return files;
+    }
+
+    async runRegexQuery(query) {
+        let regex;
+        const literalMatch = query.match(/^\/(.*)\/([gimsuy]*)$/);
+
+        if (literalMatch) {
+            regex = new RegExp(literalMatch[1], literalMatch[2] || 'm');
+        } else {
+            regex = new RegExp(query, 'm');
+        }
+
+        const files = this.plugin.app.vault.getMarkdownFiles();
+        const matches = [];
+
+        for (const file of files) {
+            const content = await this.plugin.app.vault.cachedRead(file);
+            if (regex.test(content)) {
+                matches.push(file);
+            }
+        }
+
+        return matches;
+    }
+}
+
+module.exports = QueryProcessor;

--- a/src/static-renderer.js
+++ b/src/static-renderer.js
@@ -1,0 +1,62 @@
+const { Component, MarkdownRenderer } = require('obsidian');
+
+class StaticRenderer {
+    constructor(plugin) {
+        this.plugin = plugin;
+    }
+
+    async render(container, results, ctx, onClickResult) {
+        container.empty();
+        container.addClass('sync-container');
+
+        const component = new Component();
+        component.load();
+        ctx.addChild(component);
+
+        if (!results.length) {
+            container.createDiv('sync-empty').setText('No matching blocks found for sync-query.');
+            return;
+        }
+
+        for (const result of results) {
+            const item = container.createDiv('sync-embed-static');
+            item.dataset.file = result.file.path;
+            item.tabIndex = 0;
+            await this.renderResultIntoElement(item, result, ctx, component);
+
+            const clickHandler = async (event) => {
+                event.preventDefault();
+                event.stopPropagation();
+                await onClickResult(result, item);
+            };
+
+            item.addEventListener('click', clickHandler);
+            const keydownHandler = async (event) => {
+                if (event.key === 'Enter' || event.key === ' ') {
+                    await clickHandler(event);
+                }
+            };
+
+            item.addEventListener('keydown', keydownHandler);
+
+            component.register(() => {
+                item.removeEventListener('click', clickHandler);
+                item.removeEventListener('keydown', keydownHandler);
+            });
+        }
+    }
+
+    async renderResultIntoElement(element, result, ctx, component = null) {
+        let renderComponent = component;
+        if (!renderComponent) {
+            renderComponent = new Component();
+            renderComponent.load();
+            ctx.addChild(renderComponent);
+        }
+        element.empty();
+        const body = element.createDiv('sync-embed-static-body');
+        await MarkdownRenderer.renderMarkdown(result.originalText, body, ctx.sourcePath, renderComponent);
+    }
+}
+
+module.exports = StaticRenderer;

--- a/src/viewport-controller.js
+++ b/src/viewport-controller.js
@@ -28,6 +28,22 @@ class ViewportController {
         this.scrollToSection(embedData);
     }
 
+    async setupBlockViewport(embedData, startLine, endLine) {
+        await new Promise(resolve => setTimeout(resolve, 100));
+
+        embedData.sectionInfo = {
+            startLine,
+            endLine,
+            headerLevel: 0
+        };
+        embedData.viewportActive = true;
+
+        this.applyViewportRestriction(embedData);
+        this.setupBoundaryProtection(embedData);
+        this.setupContentConstraints(embedData);
+        this.scrollToSection(embedData);
+    }
+
     applyViewportRestriction(embedData) {
         const { view } = embedData;
         
@@ -138,6 +154,7 @@ class ViewportController {
     setupHeaderInputInterception(embedData) {
         const { view, editor, component } = embedData;
         const { headerLevel } = embedData.sectionInfo;
+        if (!headerLevel) return;
 
         let lastNoticeTime = 0;
         const noticeDebounce = 5000;
@@ -322,6 +339,16 @@ class ViewportController {
 
     updateViewportImmediately(embedData) {
         if (!embedData.viewportActive) return;
+
+        if (embedData.mode === 'block' && embedData.blockBounds) {
+            embedData.sectionInfo = {
+                startLine: embedData.blockBounds.startLine,
+                endLine: embedData.blockBounds.endLine,
+                headerLevel: 0
+            };
+            if (embedData.viewportStyle) this.updateViewportCSS(embedData, embedData.viewportStyle);
+            return;
+        }
 
         const currentContent = embedData.editor.getValue();
         const newSectionInfo = this.findSectionBounds(currentContent, embedData.section);

--- a/styles.css
+++ b/styles.css
@@ -453,3 +453,21 @@ body.sync-embeds-no-focus-highlight .sync-embed:focus-within {
     display: block;
   }
 }
+/* === STATIC QUERY RENDERING === */
+.sync-embed-static {
+  border: 1px solid var(--background-modifier-border);
+  border-radius: 4px;
+  padding: 12px 16px;
+  background: var(--background-primary);
+  cursor: pointer;
+}
+
+.sync-embed-static:hover {
+  border-color: var(--interactive-accent);
+  background: var(--background-primary-alt);
+}
+
+.sync-embed-static:focus {
+  outline: 2px solid var(--interactive-accent);
+  outline-offset: 2px;
+}


### PR DESCRIPTION
### Motivation
- Provide a safe, memory-efficient `sync-query` code-block feature that can query the vault, extract matching blocks, and present an editable dashboard without spawning a WorkspaceLeaf per result. 
- Render results as static HTML and only create a single live editor when the user elects to edit a specific block, then destroy that leaf on blur to avoid RAM exhaustion. 

### Description
- Add a new `QueryProcessor` (`src/query-processor.js`) that parses YAML from the `sync-query` code block and routes queries to `native`, `dataview`, or `regex` adapters, with graceful fallback when Dataview is missing. 
- Add `BlockExtractor` (`src/block-extractor.js`) to extract `task`, `callout`, `list`, or `any` block types from matched files and to capture `^block-id` identifiers. 
- Add `StaticRenderer` (`src/static-renderer.js`) to render each `QueryResult` via `MarkdownRenderer.renderMarkdown()` into static `.sync-embed-static` cards and attach click/keyboard handlers to initiate hot-swap. 
- Wire a new `sync-query` processor in `src/main.js` that orchestrates the 4-phase flow (parse/fetch → extract → static render → static-to-live hot-swap), resolves block bounds via metadata or exact `indexOf(originalText)` matching, shows a `Notice` on ambiguous duplicates, and refreshes the static card after teardown. 
- Extend `EmbedManager.loadEmbed` (in `src/embed-manager.js`) to accept a `mode` (`section` | `block`) and optional `blockBounds`, return `embedData` to callers, and add `destroyEmbed(embedData)` for complete unload/detach. 
- Extend `ViewportController` (`src/viewport-controller.js`) with `setupBlockViewport(startLine, endLine)` and block-aware update logic so existing viewport protections (boundary keys, header hinting, frontmatter DOM offset) are reused for arbitrary line ranges. 
- Add minimal styling for static cards in `styles.css` under `.sync-embed-static`. 
- Enforce guardrails: no automatic file writes of `^block-id`, duplicate-text resolution aborts with a `Notice`, and only a single live WorkspaceLeaf is active per `sync-query` block at a time. 

### Testing
- Ran build: `npm run build` completed successfully. 
- Verified repository changes were committed (code built and compiled as part of the repository build step).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699df2102418832b8d5743bfbec84216)